### PR TITLE
Fix issue with request header generated helper

### DIFF
--- a/service-compiler/src/main/java/io/techery/janet/HttpHelpersGenerator.java
+++ b/service-compiler/src/main/java/io/techery/janet/HttpHelpersGenerator.java
@@ -323,7 +323,7 @@ public class HttpHelpersGenerator extends Generator<HttpActionClass> {
         for (Element element : actionClass.getAnnotatedElements(ResponseHeader.class)) {
             ResponseHeader annotation = element.getAnnotation(ResponseHeader.class);
             String fieldAddress = getFieldAddress(actionClass, element);
-            builder.addStatement(fieldAddress + " = $L.make($S)", element.toString(), PARENT_HELPER_FIELD_NAME, annotation
+            builder.addStatement(fieldAddress + " = $L.get($S)", element.toString(), PARENT_HELPER_FIELD_NAME, annotation
                     .value());
         }
     }


### PR DESCRIPTION
Current implementation of HttpHelpersGenerator causes compile time error in generated helpers. Generated code tries to call `make` method on `HashMap`.
