### PR TITLE
Add Request/Response details to HttpException

### DIFF
--- a/service/src/main/java/io/techery/janet/HttpActionService.java
+++ b/service/src/main/java/io/techery/janet/HttpActionService.java
@@ -126,7 +126,7 @@ final public class HttpActionService extends ActionService {
             }
             action = helper.onResponse(action, response, converter);
             if (!response.isSuccessful()) {
-                throw new HttpException(response);
+                throw HttpException.forResponse(request, response);
             }
             throwIfCanceled(action, request);
         } catch (CancelException e) {
@@ -140,7 +140,7 @@ final public class HttpActionService extends ActionService {
             }
             throw new HttpServiceException(cause);
         } catch (Throwable e) {
-            throw new HttpServiceException(e);
+            throw new HttpServiceException(HttpException.forRequest(request, e));
         } finally {
             if (request != null) {
                 List<Request> requests = runningRequests.get(action);

--- a/service/src/main/java/io/techery/janet/http/exception/HttpException.java
+++ b/service/src/main/java/io/techery/janet/http/exception/HttpException.java
@@ -1,17 +1,54 @@
 package io.techery.janet.http.exception;
 
 
+import java.net.SocketTimeoutException;
+
+import io.techery.janet.http.model.Request;
 import io.techery.janet.http.model.Response;
 
+/**
+ * Exception to indicate Http Request/Response fail.
+ * <ul>
+ *     <li> Fail on response (status code is out of 2xx) will contain both {@link Request} and {@link Response} models.</li>
+ *     <li> Fail on request (e.g. {@link SocketTimeoutException}) will contain {@link Request} and {@link Throwable} cause.</li>
+ * </ul>
+ *
+ * See {@code isFailedOnRequest}, getRequest, getResponse, getCause for details.
+ */
 public class HttpException extends Exception {
+
+    private final Request request;
     private final Response response;
 
-    public HttpException(Response response) {
-        super("HTTP " + response.getStatus() + " " + response.getReason());
+    public static HttpException forRequest(Request request, Throwable cause) {
+        return new HttpException(request, null, cause);
+    }
+
+    public static HttpException forResponse(Request request, Response response) {
+        return new HttpException(request, response, null);
+    }
+
+    private HttpException(Request request, Response response, Throwable cause) {
+        super(createMessage(request, response), cause);
+        this.request = request;
         this.response = response;
+    }
+
+    private static String createMessage(Request request, Response response) {
+        return response == null ?
+                "HTTP call failed on request" :
+                "HTTP call failed on response with status=" + response.getStatus() + ", with reason=" + response.getReason();
+    }
+
+    public Request getRequest() {
+        return request;
     }
 
     public Response getResponse() {
         return response;
+    }
+
+    public boolean isRequestFail() {
+        return response == null;
     }
 }


### PR DESCRIPTION
## Problem
There is no way to get request/response raw data out of `HttpException` if something goes wrong: e.g. `SocketTimeoutException`. Sometimes you want this data: full url, headers, etc.

## Solution
Add request/response models to `HttpException` accordingly 

Example of stack trace for request-related issue:
```
io.techery.janet.http.exception.HttpServiceException: io.techery.janet.http.exception.HttpException: HTTP call failed on request
	at io.techery.janet.HttpActionService.sendInternal(HttpActionService.java:143)
	...
	at io.techery.janet.http.sample.HttpSample.main(HttpSample.java:70)
Caused by: io.techery.janet.http.exception.HttpException: HTTP call failed on request
	at io.techery.janet.http.exception.HttpException.forRequest(HttpException.java:24)
	... 25 more
Caused by: java.net.UnknownHostException: httpbin1.org: unknown error
```